### PR TITLE
feat: New 'pinned' command

### DIFF
--- a/cogs/help.py
+++ b/cogs/help.py
@@ -18,14 +18,16 @@ class NewHelpCog(commands.Cog):
             logger.removeHandler(h)
 
     # TODO: NBC-specific CMD Ideas
-    # - website (sends a link to our website + other socials?)
     # - A "list staff team" command or just a "members in @role"
     # - Make moderation commands more useful and optimized, if I ever make
     #   something as sophisticated as localbot then we would switch over.
-    # - Add simple VC mute and deafen commands
     # - Add simple nickname change command
     # - At some point move custom commands over to this bot
     # - Auto response? Like in PCMR
+
+    # TODO: Where needed...
+    #       Add a "Permissions" tag that mentions requirements
+    #       Add "Cooldown" tag that describes ratelimits (1 per 30, etc.)
 
     @commands.group()
     async def help(self, ctx):
@@ -51,9 +53,9 @@ class NewHelpCog(commands.Cog):
                 inline=False
             )
             embed.add_field(
-                name="Utility Commands [7]",
+                name="Utility Commands [8]",
                 value="`about`, `avatar`, `changelog`, `joinpos`, `ping`, "
-                      "`suggest`, `whois`",
+                      "`pinned`, `suggest`, `whois`",
                 inline=False
             )
             embed.add_field(
@@ -124,6 +126,7 @@ class NewHelpCog(commands.Cog):
         cmd_aliases = f"`{'`, `'.join(cmd.aliases)}`"
 
         embed = discord.Embed(
+            title=f"{config.BOT_PREFIX}{cmd.name}",
             description=f"Learn what's new with this version of the bot"
                         "\n\n**Type:** Utility"
                         f"\n**Usage:** `{config.BOT_PREFIX}"
@@ -145,6 +148,7 @@ class NewHelpCog(commands.Cog):
         cmd_aliases = f"`{'`, `'.join(cmd.aliases)}`"
 
         embed = discord.Embed(
+            title=f"{config.BOT_PREFIX}{cmd.name}",
             description=f"States the position that a specified user joined "
                         "the server. E.g. Joe is member #50 out of 550"
                         "\n\n**Type:** Utility"
@@ -167,10 +171,34 @@ class NewHelpCog(commands.Cog):
         cmd = self.bot.get_command("ping")
 
         embed = discord.Embed(
+            title=f"{config.BOT_PREFIX}{cmd.name}",
             description=f"Tests my connection to Discord"
                         "\n\n**Type:** Utility"
                         f"\n**Usage:** `{config.BOT_PREFIX}"
                         f"{cmd.name}`",
+            colour=config.BOT_COLOUR
+        )
+        embed.set_author(
+            name=f"{config.BOT_HELP_ANAME}",
+            url=config.BOT_URL,
+            icon_url=self.bot.user.avatar_url
+        )
+        embed.set_footer(text=config.BOT_FOOTER)
+        await ctx.send(embed=embed)
+
+    @help.command()
+    async def pinned(self, ctx):
+        cmd = self.bot.get_command("pinned")
+        cmd_aliases = f"`{'`, `'.join(cmd.aliases)}`"
+
+        embed = discord.Embed(
+            title=f"{config.BOT_PREFIX}{cmd.name}",
+            description=f"Retrieves information about a channel's pinned "
+                        "messages"
+                        "\n\n**Type:** Utility"
+                        f"\n**Usage:** `{config.BOT_PREFIX}"
+                        f"{cmd.name} <channel>`"
+                        f"\n**Aliases:** {cmd_aliases}",
             colour=config.BOT_COLOUR
         )
         embed.set_author(
@@ -187,6 +215,7 @@ class NewHelpCog(commands.Cog):
         cmd_aliases = f"`{'`, `'.join(cmd.aliases)}`"
 
         embed = discord.Embed(
+            title=f"{config.BOT_PREFIX}{cmd.name}",
             description=f"Retrieves information about this server"
                         "\n\n**Type:** Utility"
                         f"\n**Usage:** `{config.BOT_PREFIX}"
@@ -207,13 +236,14 @@ class NewHelpCog(commands.Cog):
         cmd = self.bot.get_command("suggest")
 
         embed = discord.Embed(
-            description=f"Allows you to report a bug or suggest ideas for new "
-                        "commands/improvements to existing ones. Your "
-                        "response will be sent in "
-                        f"{config.SUGGEST_CHANNEL_ID}."
+            title=f"{config.BOT_PREFIX}{cmd.name}",
+            description=f"Allows you to report a bug, suggest ideas for new "
+                        "commands or suggest improvements for existing ones. "
+                        "Your response will be sent in "
+                        f"<#{config.SUGGEST_CHANNEL_ID}>."
                         "\n\n**Type:** Utility"
                         f"\n**Usage:** `{config.BOT_PREFIX}"
-                        f"{cmd.name} <yoursuggestion>`",
+                        f"{cmd.name} <suggestion-text-here>`",
             colour=config.BOT_COLOUR
         )
         embed.set_author(
@@ -230,6 +260,7 @@ class NewHelpCog(commands.Cog):
         cmd_aliases = f"`{'`, `'.join(cmd.aliases)}`"
 
         embed = discord.Embed(
+            title=f"{config.BOT_PREFIX}{cmd.name}",
             description=f"Retrieves relevant information about a specified "
                         "user in the server"
                         "\n\n**Type:** Utility"
@@ -253,6 +284,7 @@ class NewHelpCog(commands.Cog):
         cmd_aliases = f"`{'`, `'.join(cmd.aliases)}`"
 
         embed = discord.Embed(
+            title=f"{config.BOT_PREFIX}{cmd.name}",
             description=f"Bans a specified user from the server."
                         "\n\n**Type:** Moderation"
                         f"\n**Usage:** `{config.BOT_PREFIX}"
@@ -276,6 +308,7 @@ class NewHelpCog(commands.Cog):
         cmd_aliases = f"`{'`, `'.join(cmd.aliases)}`"
 
         embed = discord.Embed(
+            title=f"{config.BOT_PREFIX}{cmd.name}",
             description=f"Kicks a specified user from the server."
                         "\n\n**Type:** Moderation"
                         f"\n**Usage:** `{config.BOT_PREFIX}"
@@ -298,12 +331,13 @@ class NewHelpCog(commands.Cog):
         cmd_aliases = f"`{'`, `'.join(cmd.aliases)}`"
 
         embed = discord.Embed(
+            title=f"{config.BOT_PREFIX}{cmd.name}",
             description=f"Deletes a specified number of messages from the "
                         "current channel."
                         "\n\n**Type:** Moderation"
                         "\n**Permissions:** Manage Messages"
                         f"\n**Usage:** `{config.BOT_PREFIX}"
-                        f"{cmd.name} <# of messages to delete>`"
+                        f"{cmd.name} <#-of-messages-to-delete>`"
                         f"\n**Aliases:** {cmd_aliases}",
             colour=config.BOT_COLOUR
         )
@@ -314,8 +348,6 @@ class NewHelpCog(commands.Cog):
         )
         embed.set_footer(text=config.BOT_FOOTER)
         await ctx.send(embed=embed)
-
-    # TODO: Add a "permissions" tag that mentions requirements
 
 
 def setup(bot):

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -30,7 +30,7 @@ def fmt_seconds_friendly(second):
 # Meant for when passing raw datetimes that include year, month, day, etc.
 # Returned Formatting: Wed, Jul 1, 1987 17:44 PM GMT
 def fmt_time_friendly(time):
-    return time.strftime("%a, %b %-d, %Y %H:%M %p")
+    return time.strftime("%a, %b X%d, %Y %H:%M %p").replace("X0", "X").replace("X", "")
 
 
 # In weeks format for whois and serverinfo, maybe rename it to something else


### PR DESCRIPTION
<!--
Add discord.py-style checklist just for ease of having a summary of changes
https://github.com/Rapptz/discord.py/pull/6179
-->

## Summary

This PR introduces a new bot command called `pinned` and its accompanying help command. The command takes an optional channel argument and provides certain information about said channel. Specifically...
* Channel ID
* Number of Pinned Messages in the channel
* The most recently pinned message (if applicable)

The second bullet point was the primary motivation behind adding this command as it saves having to manually count. Why would you need to count how many pinned messages you have in a channel you ask? Because it helps me keep track of how close a channel might be to hitting the max allowed # of pinned messages (which is currently 50).

Other minor changes documented within this PR's commits (which honestly should have been in their own commits) include:
* Improving code readability (by a marginal amount) by renaming the `tools.convert_seconds_friendly()` & `tools.get_time_friendly()` methods.
* Changing all references of `ctx.channel.send` to `ctx.send`. Either one achieves the same result, so I decided on one of them and will now stay consistent to it in future code.
* Change behaviour of `tools.fmt_time_friendly()` method to remove leading zeros in front of calendar days (e.g. Nov 02, 2020 will now be displayed as Nov 2, 2020).

## Checklist

<!-- Add an x inside [ ] to check that item off, like this: [x] -->

- [x] I have checked all open [pull requests](https://github.com/lukadd16/NBC-Boterator/pulls) for duplicates of this one.
- [x] If code changes were made, they have been tested.
    - [x] Code changes follow the [PEP 8](https://www.python.org/dev/peps/pep-0008/) style guide.
- [ ] This PR **fixes an issue**
- [x] This PR adds something **new** (new methods/parameters added, etc.)
- [ ] This PR is a **breaking change** (methods/parameters removed or renamed, etc.)
- [ ] This PR is **not** a code change (documentation, README, etc.)
