### PR TITLE
feat: New Partners Cog

### DIFF
--- a/cogs/partners.py
+++ b/cogs/partners.py
@@ -1,0 +1,171 @@
+# Description: Cog with commands relevant to new server partnership system
+
+import app_logger
+import asyncio
+import config
+import discord
+import json
+import os
+
+from datetime import datetime
+from discord.ext import commands
+
+logger = app_logger.get_logger(__name__)
+
+# Two commands: addpartner, editpartner
+#   - Haven't decided but would make more sense that addpartner resolves server name, server icon, those things from the provided invite
+#   --> Args using invite method: self, ctx, invite, description (or type this in an interactive menu later?), banner = None (which can be different from server banner), colour: str = discord.Embed.empty (when asking in interactive menu, either say default or type the hex code), ???
+#   --> Args using manual method: self, ctx, title, description, banner, colour, invite, ???
+#
+#   - editpartner would take msgID as an arg, then interactive menu will ask which part want to edit (type 1 for all, 2 for title, 3 for desc, etc.)
+#   --> Remember, not sending a new embed, merely editing the one that is already there (figure out how retrieving the embed will work)
+
+# Reference "refresh" command for how to edit an existing embed
+
+# Could integrate ext.Menus reaction menu functionality into the confirmation at the end (e.g. "Here is a preview of the embed, does everything look good? Please react below.")
+# Didn't work last time I tried, but will attempt to use emoji check for final confirmation (not sure what want behaviour to be yet though)
+
+# Add logger events where necessary
+
+db_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../data")
+db_dir = os.path.join(db_dir, "db")
+db_file_name = "partners.json"
+db_file_path = os.path.join(db_dir, db_file_name)
+logger.info("JSON File Path: {}".format(db_file_path))
+
+
+class Partners(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.partner_channel = self.bot.get_channel(
+            config.PARTNERS_CHANNEL_ID
+        )
+        # self.partner_msg = self.partner_channel.fetch_message(
+        #     config.PARTNERS_MSG_ID
+        # )
+
+    def cog_unload(self):
+        for h in logger.handlers:
+            logger.removeHandler(h)
+
+    @commands.group(aliases=["partners"])
+    @commands.has_guild_permissions()
+    async def partner(self, ctx):
+        # Could use the base command to explain how to partner, etc. (could also add a link via MD to the requirements embed)
+        pass
+
+    # This'll be the command that sends the initial requirements embed, should also add one called edit_requirements (which'll retrieve the embed from ID, create an embed object using data from partners.json which we will assume has been editted)
+    @partner.command(aliases=["send", "sreq"])
+    @commands.has_guild_permissions(administrator=True)
+    async def send_requirements(self, ctx):
+        with open(db_file_path, "rb") as f:
+            data = json.load(f)
+            logger.debug("JSON Data Loaded")
+
+        # Construct initial embed using data from our json file
+        embed = discord.Embed(
+            title="{}".format(data['requirementsEmbed']['title']),
+            description="{}".format(data['requirementsEmbed']['description']),
+            colour=config.BOT_COLOUR,
+            timestamp=datetime.utcnow()  # This attr is timezone aware
+        )
+        embed.add_field(
+            name="{}".format(data['requirementsEmbed']['fields']['partnerReq']['name']),
+            value="{}".format('\n'.join(map(str, data['requirementsEmbed']['fields']['partnerReq']['value']))),
+            inline=False
+        )
+        embed.add_field(
+            name="{}".format(data['requirementsEmbed']['fields']['howApply']['name']),
+            value="{}".format('\n'.join(map(str, data['requirementsEmbed']['fields']['howApply']['value']))),
+            inline=False
+        )
+        embed.add_field(
+            name="{}".format(data['requirementsEmbed']['fields']['miscNotes']['name']),
+            value="{}".format('\n'.join(map(str, data['requirementsEmbed']['fields']['miscNotes']['value']))),
+            inline=False
+        )
+        embed.set_footer(
+            text="{}".format(data['requirementsEmbed']['footer']['text']),
+            icon_url=ctx.guild.icon_url
+        )
+
+        partner_msg = await self.partner_channel.send(embed=embed)
+        await ctx.send("**`SUCCESS`**` (ID: {})".format(  # Copy this + logger format for official.py commands where need the ID of the embeds sent
+                partner_msg.id
+            )
+        )
+        logger.info(
+            "Partnership Requirements Embed Sent (MSG ID: {})".format(
+                partner_msg.id
+            )
+        )
+
+    @partner.command(aliases=["refresh", "ereq"])
+    @commands.has_guild_permissions(administrator=True)
+    async def edit_requirements(self, ctx):
+        with open(db_file_path, "rb") as f:
+            data = json.load(f)
+            logger.debug("JSON Data Loaded")
+
+        # Construct new embed using updated data from our json file
+        new_embed = discord.Embed(
+            title="{}".format(data['requirementsEmbed']['title']),
+            description="{}".format(data['requirementsEmbed']['description']),
+            colour=config.BOT_COLOUR,
+            timestamp=datetime.utcnow()
+        )
+        new_embed.add_field(
+            name="{}".format(data['requirementsEmbed']['fields']['partnerReq']['name']),
+            value="{}".format('\n'.join(map(str, data['requirementsEmbed']['fields']['partnerReq']['value']))),
+            inline=False
+        )
+        new_embed.add_field(
+            name="{}".format(data['requirementsEmbed']['fields']['howApply']['name']),
+            value="{}".format('\n'.join(map(str, data['requirementsEmbed']['fields']['howApply']['value']))),
+            inline=False
+        )
+        new_embed.add_field(
+            name="{}".format(data['requirementsEmbed']['fields']['miscNotes']['name']),
+            value="{}".format('\n'.join(map(str, data['requirementsEmbed']['fields']['miscNotes']['value']))),
+            inline=False
+        )
+        new_embed.set_footer(
+            text="{}".format(data['requirementsEmbed']['footer']['text']),
+            icon_url=ctx.guild.icon_url
+        )
+
+        # Retrieve necessary details about the message we want to edit
+        guild = discord.utils.get(
+            self.bot.guilds,
+            name="Jarvis Bot"
+        )
+        channel = discord.utils.get(
+            guild.text_channels,
+            id=config.PARTNERS_CHANNEL_ID
+        )
+        msg = await channel.fetch_message(
+            config.PARTNERS_MSG_ID
+        )
+
+        await msg.edit(embed=new_embed)
+        await ctx.send("**`SUCCESS`**")
+        logger.info(
+            "Partnership Requirements Embed Edited (MSG ID: {})".format(
+                msg.id
+            )
+        )
+
+    # For now going to lock to admins only
+    @partner.command()
+    @commands.has_guild_permissions(administrator=True)
+    async def add(self, ctx):
+        pass
+
+    @partner.command()
+    @commands.has_guild_permissions(administrator=True)
+    async def edit(self, ctx):
+        pass
+
+
+def setup(bot):
+    bot.add_cog(Partners(bot))

--- a/cogs/partners.py
+++ b/cogs/partners.py
@@ -37,12 +37,6 @@ logger.info("JSON File Path: {}".format(db_file_path))
 class Partners(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-        # self.partner_channel = self.bot.get_channel(
-        #     config.PARTNERS_CHANNEL_ID
-        # )
-        # self.partner_msg = self.partner_channel.fetch_message(
-        #     config.PARTNERS_MSG_ID
-        # )
 
     def cog_unload(self):
         for h in logger.handlers:
@@ -208,6 +202,7 @@ class Partners(commands.Cog):
 
     # For now going to lock to admins only
     # After/together with this I should create an inviteinfo command (alias = ii)
+    # TODO: Do I need a local error handler at all? Or have I already convered most cases within each command?
     @partner.command()
     @commands.has_guild_permissions(administrator=True)
     async def add(self, ctx, invite: discord.Invite, rep: discord.Member, colour: str = None, banner: str = None):  # Remember that colour codes need to be 0x...
@@ -218,26 +213,6 @@ class Partners(commands.Cog):
             colour = discord.Embed.Empty  # Or discord.Colour.dark_theme() which would blend in with dark mode
         else:  # Convert string to valid integer type
             colour = int(colour, 16)
-
-
-        # Will resolve guild name, server icon, etc. from the invite itself
-        # Handle various errors appropriately in own local err handler
-
-        # Args using invite method: self, ctx, invite, description (or type this in an interactive menu later?), banner = None (which can be different from server banner), colour: str = discord.Embed.empty (when asking in interactive menu, either say default or type the hex code), ???
-
-        # Embed description will be for the description blurb I was provided with
-        # And on second thought, desc as a param isn't feasible considering that descriptions will be more than just sentences.
-
-        # Banner param should be provided as a URL (ideally a cdn.discordapp.com one)
-
-        # Embed fields: Representative, Invite
-        # Embed thumbnail will be the guild icon
-        # Embed image will be the guild banner (that I am provided with)
-
-        # Embed footer: Northbridge Cafe Partnership Program, timestamp=datetime.utcnow()
-
-        # Retrieve guild that the invite points to
-        # invite_guild = invite.guild
 
         # Confirm invite returns a valid guild
         if invite.guild is None:
@@ -259,36 +234,6 @@ class Partners(commands.Cog):
             await ctx.message.delete()  # Delete command invokation
             await ctx.channel.send(embed=embed)
             return
-
-        # Retrieve other information about the guild
-        # guild_name = guild.name
-        # guild_icon = guild.icon_url
-
-        # Retrieve partnership representative member
-        # rep_member = discord.utils.get(ctx.guild.members, id=rep_id)
-
-        # utils.get() will return None if could not find a member with that ID
-        # if rep_member is None:
-        #     embed = discord.Embed(
-        #         title="ERROR",
-        #         description="I could not find a member with a matching uID, "
-        #                     "please try again.",
-        #         colour=config.BOT_ERR_COLOUR,
-        #         timestamp=datetime.utcnow()
-        #     )
-        #     embed.set_author(
-        #         name=config.BOT_AUTHOR_NAME,
-        #         url=config.BOT_URL,
-        #         icon_url=self.bot.user.avatar_url
-        #     )
-        #     embed.set_footer(
-        #         text="Offending uID: {}".format(rep_id)
-        #     )
-        #     await ctx.message.delete()  # Delete command invokation
-        #     await ctx.channel.send(embed=embed)
-        #     return
-
-        # In theory discord.Member type should already attempt to use MemberConverter() to get the proper type
 
         embed = discord.Embed(
             title="PARTNERSHIP MENU",
@@ -355,12 +300,10 @@ class Partners(commands.Cog):
         )
         embed.add_field(
             name="{} Representative".format("\U0001f465"),
-            # value="{} {}".format("\U0001f465", rep.mention)
             value="{}".format(rep.mention)
         )
         embed.add_field(
             name="{} Invite".format("\U0001f517"),
-            # value="{} **{}**".format("\U0001f517", invite.url)  # TODO: Experiment with the spacing
             value="**{}**".format(invite.url)
         )
         embed.set_thumbnail(

--- a/data/db/partners.json
+++ b/data/db/partners.json
@@ -1,0 +1,50 @@
+{
+    "requirementsEmbed": {
+        "title": "<:partneredServer:806200535518019585> Northbridge Café Partnership Program <:partneredServer:806200535518019585>",
+        "description": "Hey! This channel is home to partners of Northbridge Café. If you are interested in becoming a partner with us, please make sure that you read and understand everything outlined below.\n\u200B",
+        "fields": {
+            "partnerReq": {
+                "name": "📜 | __**Requirements**__ | 📜",
+                "value": [
+                    "> ` • ` Server must follow + enforce Discord **[TOS](https://discord.com/terms)** & **[Guidelines](https://discord.com/guidelines)** in their entirety",
+                    "> ` • ` Server must not revolve around pornographic/sexual content",
+                    "> ` • ` 250+ members (excluding bots)",
+                    "> ` • ` 15k+ messages sent in the primary/general text channel",
+                    "> ` • ` 2500+ messages sent every two weeks (we use <@491769129318088714> to track this)",
+                    "> <:uFXimportant:790336567217750028> **Note:** Meeting the above requirements does *not* guarantee partnership.",
+                    "\u200B"
+                ]
+            },
+            "howApply": {
+                "name": "📩 | __**How To Apply**__ | 📩",
+                "value":[
+                    "> Once you have read this message **in its entirety**, DM <@243319767040131072> or open up a ModMail Ticket (preferably the former).",
+                    "\u200B"
+                ]
+            },
+            "miscNotes": {
+                "name": "📚 | __**Miscellaneous Notes**__ | 📚",
+                "value": [
+                    "> ` • ` Partnership is open to servers of all topics (not just tech-related ones).",
+                    "> ` • ` We do not ping \\@everyone or \\@here for partners. There are no exceptions to this rule!",
+                    "> ` • ` You must have one member of your staff team join this server. They will act as a representative of your server, and as a form of recognition will be given the <@&669376302188331068> role.",
+                    "\u200B",
+                    "> <:uFXimportant:790336567217750028> **Important:** If your server's representative leaves without declaring a sucessor, your partnership status will be suspended and server ad subsequently deleted.",
+                    "\n*If you have any questions, please direct them to <@243319767040131072>.*"
+                ]
+            },
+            "blank": {
+                "name": "\u200B",
+                "value": [
+                    "*If you have any questions, please direct them to <@243319767040131072>.*"
+                ]
+            }
+        },
+        "footer": {
+            "text": "Northbridge Café Executive Team"
+        }
+    },
+    "templateEmbed": {
+        "title": "TBD"
+    }
+}

--- a/data/db/partners.json
+++ b/data/db/partners.json
@@ -11,7 +11,7 @@
                     "> ` • ` 250+ members (excluding bots)",
                     "> ` • ` 15k+ messages sent in the primary/general text channel",
                     "> ` • ` 2500+ messages sent every two weeks (we use <@491769129318088714> to track this)",
-                    "> <:uFXimportant:790336567217750028> **Note:** Meeting the above requirements does *not* guarantee partnership.",
+                    "> <:uFXimportant:790336567217750028> **Note:** Meeting the above requirements *does not guarantee* partnership.",
                     "\u200B"
                 ]
             },

--- a/data/db/partners.json
+++ b/data/db/partners.json
@@ -29,7 +29,7 @@
                     "> ` • ` We do not ping \\@everyone or \\@here for partners. There are no exceptions to this rule!",
                     "> ` • ` You must have one member of your staff team join this server. They will act as a representative of your server, and as a form of recognition will be given the <@&669376302188331068> role.",
                     "\u200B",
-                    "> <:uFXimportant:790336567217750028> **Important:** If your server's representative leaves without declaring a sucessor, your partnership status will be suspended and server ad subsequently deleted.",
+                    "> <:uFXimportant:790336567217750028> **Important:** If your server's representative leaves without declaring a sucessor, your partnership status will be suspended and server advertisement subsequently deleted.",
                     "\n*If you have any questions, please direct them to <@243319767040131072>.*"
                 ]
             },

--- a/data/db/partners.json
+++ b/data/db/partners.json
@@ -43,8 +43,5 @@
         "footer": {
             "text": "Northbridge Café Executive Team"
         }
-    },
-    "templateEmbed": {
-        "title": "TBD"
     }
 }


### PR DESCRIPTION
<!--
Add discord.py-style checklist just for ease of having a summary of changes
https://github.com/Rapptz/discord.py/pull/6179
-->

## Summary

This PR introduces a new bot cog which contains a couple of new commands that are related to the planned overhaul of Northbridge Café's Partnership Program. At the moment all of the new commands are **restricted to administrators only**.

The existing system involved myself manually adding the advertisements + invite links for each of our server partners. This worked fine, but over time (and as this project started to take shape), I desired a more elegant and organized that made use of embeds. Thus I set out to implement this idea, which now takes the shape of this PR and the changes it contains.

Part of the overhaul was going to include a new set of requirements for servers who wanted to partner with us. The proposed implementation stores these requirements in a JSON file for ease of access and revision. Then via the `partner send` command, the bot will post an embed containing the formatted requirements in the designated `#partners` channel in the Northbridge Café discord server. If at a change needs to be made to these requirements then the `partners refresh` command will update the existing embed with the latest information from our JSON file.

After that, server partners can then be added and easily updated via the `partners add` and `partners edit` commands (which won't be explained here).

## Checklist

- [x] I have checked all open [pull requests](https://github.com/lukadd16/NBC-Boterator/pulls) for duplicates of this one.
- [x] If code changes were made, they have been tested.
    - [x] Code changes follow the [PEP 8](https://www.python.org/dev/peps/pep-0008/) style guide.
- [ ] This PR **fixes an issue**
- [x] This PR adds something **new** (new methods/parameters added, etc.)
- [ ] This PR is a **breaking change** (methods/parameters removed or renamed, etc.)
- [ ] This PR is **not** a code change (documentation, README, etc.)
