### PR TITLE
chore: Renaming Constants Defined in Config File

### DIFF
--- a/cogs/help.py
+++ b/cogs/help.py
@@ -44,7 +44,7 @@ class NewHelpCog(commands.Cog):
             )
             embed.set_author(
                 name="NBC Boterator Command List",
-                url=config.BOT_URL,
+                url=config.WEBSITE_URL,
                 icon_url=self.bot.user.avatar_url
             )
             embed.add_field(
@@ -90,7 +90,7 @@ class NewHelpCog(commands.Cog):
         )
         embed.set_author(
             name=f"{config.BOT_HELP_ANAME}",
-            url=config.BOT_URL,
+            url=config.WEBSITE_URL,
             icon_url=self.bot.user.avatar_url
         )
         embed.set_footer(text=config.BOT_FOOTER)
@@ -114,7 +114,7 @@ class NewHelpCog(commands.Cog):
         )
         embed.set_author(
             name=f"{config.BOT_HELP_ANAME}",
-            url=config.BOT_URL,
+            url=config.WEBSITE_URL,
             icon_url=self.bot.user.avatar_url
         )
         embed.set_footer(text=config.BOT_FOOTER)
@@ -136,7 +136,7 @@ class NewHelpCog(commands.Cog):
         )
         embed.set_author(
             name=f"{config.BOT_HELP_ANAME}",
-            url=config.BOT_URL,
+            url=config.WEBSITE_URL,
             icon_url=self.bot.user.avatar_url
         )
         embed.set_footer(text=config.BOT_FOOTER)
@@ -160,7 +160,7 @@ class NewHelpCog(commands.Cog):
         )
         embed.set_author(
             name=f"{config.BOT_HELP_ANAME}",
-            url=config.BOT_URL,
+            url=config.WEBSITE_URL,
             icon_url=self.bot.user.avatar_url
         )
         embed.set_footer(text=config.BOT_FOOTER)
@@ -180,7 +180,7 @@ class NewHelpCog(commands.Cog):
         )
         embed.set_author(
             name=f"{config.BOT_HELP_ANAME}",
-            url=config.BOT_URL,
+            url=config.WEBSITE_URL,
             icon_url=self.bot.user.avatar_url
         )
         embed.set_footer(text=config.BOT_FOOTER)
@@ -203,7 +203,7 @@ class NewHelpCog(commands.Cog):
         )
         embed.set_author(
             name=f"{config.BOT_HELP_ANAME}",
-            url=config.BOT_URL,
+            url=config.WEBSITE_URL,
             icon_url=self.bot.user.avatar_url
         )
         embed.set_footer(text=config.BOT_FOOTER)
@@ -225,7 +225,7 @@ class NewHelpCog(commands.Cog):
         )
         embed.set_author(
             name=f"{config.BOT_HELP_ANAME}",
-            url=config.BOT_URL,
+            url=config.WEBSITE_URL,
             icon_url=self.bot.user.avatar_url
         )
         embed.set_footer(text=config.BOT_FOOTER)
@@ -248,7 +248,7 @@ class NewHelpCog(commands.Cog):
         )
         embed.set_author(
             name=f"{config.BOT_HELP_ANAME}",
-            url=config.BOT_URL,
+            url=config.WEBSITE_URL,
             icon_url=self.bot.user.avatar_url
         )
         embed.set_footer(text=config.BOT_FOOTER)
@@ -272,7 +272,7 @@ class NewHelpCog(commands.Cog):
         )
         embed.set_author(
             name=f"{config.BOT_HELP_ANAME}",
-            url=config.BOT_URL,
+            url=config.WEBSITE_URL,
             icon_url=self.bot.user.avatar_url
         )
         embed.set_footer(text=config.BOT_FOOTER)
@@ -296,7 +296,7 @@ class NewHelpCog(commands.Cog):
         )
         embed.set_author(
             name=f"{config.BOT_HELP_ANAME}",
-            url=config.BOT_URL,
+            url=config.WEBSITE_URL,
             icon_url=self.bot.user.avatar_url
         )
         embed.set_footer(text=config.BOT_FOOTER)
@@ -319,7 +319,7 @@ class NewHelpCog(commands.Cog):
         )
         embed.set_author(
             name=f"{config.BOT_HELP_ANAME}",
-            url=config.BOT_URL,
+            url=config.WEBSITE_URL,
             icon_url=self.bot.user.avatar_url
         )
         embed.set_footer(text=config.BOT_FOOTER)
@@ -343,7 +343,7 @@ class NewHelpCog(commands.Cog):
         )
         embed.set_author(
             name=f"{config.BOT_HELP_ANAME}",
-            url=config.BOT_URL,
+            url=config.WEBSITE_URL,
             icon_url=self.bot.user.avatar_url
         )
         embed.set_footer(text=config.BOT_FOOTER)

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -56,7 +56,7 @@ class ModCog(commands.Cog):
             )
             embed.set_author(
                 name=config.BOT_AUTHOR_NAME,
-                url=config.BOT_URL,
+                url=config.WEBSITE_URL,
                 icon_url=self.bot.user.avatar_url
             )
             embed.set_footer(
@@ -84,7 +84,7 @@ class ModCog(commands.Cog):
             )
             embed.set_author(
                 name=config.BOT_AUTHOR_NAME,
-                url=config.BOT_URL,
+                url=config.WEBSITE_URL,
                 icon_url=self.bot.user.avatar_url
             )
             embed.set_footer(
@@ -113,7 +113,7 @@ class ModCog(commands.Cog):
             )
             embed.set_author(
                 name=config.BOT_AUTHOR_NAME,
-                url=config.BOT_URL,
+                url=config.WEBSITE_URL,
                 icon_url=self.bot.user.avatar_url
             )
             embed.set_footer(
@@ -135,7 +135,7 @@ class ModCog(commands.Cog):
             )
             embed.set_author(
                 name=config.BOT_AUTHOR_NAME,
-                url=config.BOT_URL,
+                url=config.WEBSITE_URL,
                 icon_url=self.bot.user.avatar_url
             )
             embed.add_field(
@@ -175,7 +175,7 @@ class ModCog(commands.Cog):
                     )
                     embed.set_author(
                         name=config.BOT_AUTHOR_NAME,
-                        url=config.BOT_URL,
+                        url=config.WEBSITE_URL,
                         icon_url=self.bot.user.avatar_url
                     )
                     embed.add_field(
@@ -218,7 +218,7 @@ class ModCog(commands.Cog):
                     )
                     complete.set_author(
                         name=config.BOT_AUTHOR_NAME,
-                        url=config.BOT_URL,
+                        url=config.WEBSITE_URL,
                         icon_url=self.bot.user.avatar_url
                     )
                     complete.add_field(
@@ -249,7 +249,7 @@ class ModCog(commands.Cog):
                     )
                     embed.set_author(
                         name=config.BOT_AUTHOR_NAME,
-                        url=config.BOT_URL,
+                        url=config.WEBSITE_URL,
                         icon_url=self.bot.user.avatar_url
                     )
                     embed.add_field(
@@ -279,7 +279,7 @@ class ModCog(commands.Cog):
                 )
                 embed.set_author(
                     name=config.BOT_AUTHOR_NAME,
-                    url=config.BOT_URL,
+                    url=config.WEBSITE_URL,
                     icon_url=self.bot.user.avatar_url
                 )
                 embed.add_field(
@@ -327,7 +327,7 @@ class ModCog(commands.Cog):
         )
         embed.set_author(
             name=config.BOT_AUTHOR_NAME,
-            url=config.BOT_URL,
+            url=config.WEBSITE_URL,
             icon_url=self.bot.user.avatar_url
         )
         embed.set_thumbnail(
@@ -355,7 +355,7 @@ class ModCog(commands.Cog):
         )
         embed.set_author(
             name=config.BOT_AUTHOR_NAME,
-            url=config.BOT_URL,
+            url=config.WEBSITE_URL,
             icon_url=self.bot.user.avatar_url
         )
         embed.add_field(
@@ -436,7 +436,7 @@ class ModCog(commands.Cog):
         )
         embed.set_author(
             name=config.BOT_AUTHOR_NAME,
-            url=config.BOT_URL,
+            url=config.WEBSITE_URL,
             icon_url=self.bot.user.avatar_url
         )
         embed.set_thumbnail(
@@ -498,7 +498,7 @@ class ModCog(commands.Cog):
         )
         embed.set_author(
             name=config.BOT_AUTHOR_NAME,
-            url=config.BOT_URL,
+            url=config.WEBSITE_URL,
             icon_url=self.bot.user.avatar_url
         )
         embed.set_thumbnail(

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -138,7 +138,7 @@ class OwnerCog(commands.Cog):
 
         # Report uptime & shutdown
         embed = discord.Embed(
-            title=f"Status: {config.BOT_EMOJI_OFFLINE}",
+            title=f"Status: {config.EMOJI_OFFLINE}",
             description=f"`{self.bot.user}` has been disconnected",
             colour=config.DISC_OFFLINE_COLOUR,
             timestamp=ctx.message.created_at
@@ -168,19 +168,19 @@ class OwnerCog(commands.Cog):
     async def status(self, ctx, status: str, *, reason: str):
         # TODO: Move to tools.py
         if status.lower() == "online":
-            status = config.BOT_EMOJI_ONLINE
+            status = config.EMOJI_ONLINE
             embed_colour = config.DISC_ONLINE_COLOUR
         elif status.lower() == "idle":
-            status = config.BOT_EMOJI_IDLE
+            status = config.EMOJI_IDLE
             embed_colour = config.DISC_IDLE_COLOUR
         elif status.lower() == "dnd":
-            status = config.BOT_EMOJI_DND
+            status = config.EMOJI_DND
             embed_colour = config.DISC_DND_COLOUR
         elif status.lower() == "offline":
-            status = config.BOT_EMOJI_OFFLINE
+            status = config.EMOJI_OFFLINE
             embed_colour = config.DISC_OFFLINE_COLOUR
         elif status.lower() == "stream":
-            status = config.BOT_EMOJI_STREAM
+            status = config.EMOJI_STREAM
             embed_colour = config.DISC_STREAM_COLOUR
         else:
             raise commands.BadArgument()

--- a/main.py
+++ b/main.py
@@ -67,7 +67,7 @@ class NBCBoterator(commands.Bot):
 
             except commands.ExtensionNotFound:
                 print(f"[COG] FAILED - {extension}")
-                logger.error("Failed to load cog (%s)", extension)
+                logger.error(f"Failed to load cog ({extension})")
 
         # self.login(config.BOT_TOKEN)
         # self.connect()
@@ -84,7 +84,7 @@ class NBCBoterator(commands.Bot):
 
         # Report uptime & shutdown
         embed = discord.Embed(
-            title=f"Status: {config.BOT_EMOJI_OFFLINE}",
+            title=f"Status: {config.EMOJI_OFFLINE}",
             description=f"`{self.user}` has been disconnected",
             colour=config.DISC_OFFLINE_COLOUR,
             timestamp=datetime.utcnow()
@@ -112,7 +112,7 @@ class NBCBoterator(commands.Bot):
         try:
             self.loop.run_until_complete(
                 self.start(
-                    config.BOT_TOKEN
+                    config.APP_TOKEN
                 )
             )
         except KeyboardInterrupt:
@@ -178,7 +178,7 @@ class NBCBoterator(commands.Bot):
 
         # Report bootup to status channel
         embed = discord.Embed(
-            title=f"Status: {config.BOT_EMOJI_ONLINE}",
+            title=f"Status: {config.EMOJI_ONLINE}",
             description=f"`{self.user}` has successfully connected to Discord",
             colour=config.DISC_ONLINE_COLOUR,
             timestamp=datetime.utcnow()

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -42,22 +42,22 @@ def fmt_time_friendly(time):
 # passed user; currently being used in the whois command
 def get_member_status(member):
     if f"{member.status}".lower() == "online":
-        return f"{config.BOT_EMOJI_ONLINE}"
+        return f"{config.EMOJI_ONLINE}"
     elif f"{member.status}".lower() == "idle":
-        return f"{config.BOT_EMOJI_IDLE}"
+        return f"{config.EMOJI_IDLE}"
     elif f"{member.status}".lower() == "dnd":
-        return f"{config.BOT_EMOJI_DND}"
+        return f"{config.EMOJI_DND}"
     elif f"{member.status}".lower() == "offline":
-        return f"{config.BOT_EMOJI_OFFLINE}"
+        return f"{config.EMOJI_OFFLINE}"
     else:
-        return f"{config.BOT_EMOJI_STREAM}"
+        return f"{config.EMOJI_STREAM}"
 
 
 # Return an emoji defined in the config file depending on whether the passed
 # user is a bot or not; currently being used in the whois command
 def do_bot_check(member):
     if member.bot is True:
-        return f"{config.BOT_EMOJI_BTAG}"
+        return f"{config.EMOJI_BOT_TAG}"
     else:
         return ""
 


### PR DESCRIPTION
<!--
Add discord.py-style checklist just for ease of having a summary of changes
https://github.com/Rapptz/discord.py/pull/6179
-->

## Summary

This PR simply updates the names of a few specific variable constants defined in the bot's `config.py` file, and likewise updates all references throughout the code to the outdated names. I chose to rename a select few of them in order to improve readability. So rather than each and every constant being prefixed by `BOT_`, now some are and some aren't.

**Note:** outdated references in the `utility.py` cog were addressed in commit 6ce0c902fb4b7e42d48e138200ba49f8fd19399e separately.

## Checklist

<!-- Add an x inside [ ] to check that item off, like this: [x] -->

- [x] I have checked all open [pull requests](https://github.com/lukadd16/NBC-Boterator/pulls) for duplicates of this one.
- [x] If code changes were made, they have been tested.
    - [x] Code changes follow the [PEP 8](https://www.python.org/dev/peps/pep-0008/) style guide.
- [ ] This PR **fixes an issue**
- [ ] This PR adds something **new** (new methods/parameters added, etc.)
- [ ] This PR is a **breaking change** (methods/parameters removed or renamed, etc.)
- [ ] This PR is **not** a code change (documentation, README, etc.)
